### PR TITLE
fix warning from BeautifulSoap and Fix Relative Path Problem

### DIFF
--- a/html2dash.py
+++ b/html2dash.py
@@ -27,7 +27,7 @@ def update_db(name, path):
 
 def add_urls():
     index_page = open(os.path.join(docset_path, 'index.html')).read()
-    soup = BeautifulSoup(index_page)
+    soup = BeautifulSoup(index_page, "html.parser")
     any = re.compile('.*')
     for tag in soup.find_all('a', {'href': any}):
         name = tag.text.strip()
@@ -136,7 +136,8 @@ if __name__ == "__main__":
 
     # Copy the HTML Documentation to the Docset Folder
     try:
-        subprocess.call(["cp", "-r", results.SOURCE + "/", docset_path])
+        arg_list = ["cp", "-r"] + [source_dir + "/" + f for f in os.listdir(source_dir)] + [docset_path]
+        subprocess.call(arg_list)
         print "Copy the HTML Documentation!"
     except:
         print "**Error**:  Copy Html Documents Failed..."


### PR DESCRIPTION
1. 新版的BeautifulSoap需要修改调用方式以消除Warning
2. 在Linux/Windows Linux Subsystem下Source的复制存在问题:
例如: `cp -r ../mondrian.pentaho.com/api mondrian.docset/Contents/Resources/Documents`
会把api文件夹的内容复制到mondrian.docset/Contents/Resources/Documents/api下, 而不是mondrian.docset/Contents/Resources/Documents下.