### PR TITLE
The icon path should be prefixed with the destination path.

### DIFF
--- a/html2dash.py
+++ b/html2dash.py
@@ -116,7 +116,7 @@ if __name__ == "__main__":
     # create docset directory and copy files
     doc_path = docset_name + "/Contents/Resources/Documents"
     dsidx_path = docset_name + "/Contents/Resources/docSet.dsidx"
-    icon_path = docset_name + "/icon.png"
+    icon = docset_name + "/icon.png"
     info = docset_name + "/Contents/info.plist"
 
     destpath = results.path
@@ -125,6 +125,7 @@ if __name__ == "__main__":
     docset_path = destpath + doc_path
     sqlite_path = destpath + dsidx_path
     info_path = destpath + info
+    icon_path = destpath + icon
 
     # print docset_path, sqlite_path
 


### PR DESCRIPTION
If a custom icon is used, the script (html2dash.py) is unable to copy the icon into the given destination path.

This is fixed by prefixing the icon path with the destination (it also makes it conform to the existing code-style, where other paths have been prefixed with the destination).

The open issue regarding this: #9